### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ addButton.hideWhileScrolling = YES;
 
 P.S: This was done in a short time, please feel free to contribute
 
-##License
+## License
 MIT License
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
